### PR TITLE
Add support for Go

### DIFF
--- a/api/createConf.go
+++ b/api/createConf.go
@@ -40,6 +40,7 @@ func (c *Config) writterFrom() {
 	var from string
 	images := map[string]string{
 		"node_js": "node",
+		"go":      "golang",
 	}
 	if c.version.IsValid() {
 		firstVersion := c.version.Index(0)


### PR DESCRIPTION
* The travis language is named 'go' but the Docker registry specifies it
as 'golang'