### PR TITLE
Avoid container name conflict and error when images exist without tag

### DIFF
--- a/api/cleaner.go
+++ b/api/cleaner.go
@@ -26,7 +26,7 @@ func CleanProducedImages(ctx context.Context, cli *client.Client) error {
 		return err
 	}
 	for _, image := range images {
-		if image.RepoTags[0] == "previs:latest" {
+		if len(image.RepoTags) >= 1 && image.RepoTags[0] == "previs:latest" {
 			_, err := cli.ImageRemove(ctx, image.ID, types.ImageRemoveOptions{
 				Force:         true,
 				PruneChildren: true,

--- a/api/docker.go
+++ b/api/docker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 
 	tm "github.com/buger/goterm"
@@ -71,20 +72,31 @@ func array_contains(arr []string, str string) bool {
 	return false
 }
 
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
 func startContainer(ctx context.Context, cli *client.Client, imgDocker string, pathDockerImage string, envVar []string, services []string) (string, error) {
-	hostconfig := &container.HostConfig{};
+	hostconfig := &container.HostConfig{}
 	if array_contains(services, "docker") {
 		hostconfig = &container.HostConfig{
 			Binds: []string{"/var/run/docker.sock:/var/run/docker.sock"},
 		}
 	}
+	containerName := randSeq(10)
 	respContainerCreater, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: "previs",
 		Tty:   true,
 		Env:   envVar,
-	}, hostconfig, nil, "previs")
+	}, hostconfig, nil, containerName)
 	if err != nil {
-		return "", err
+		return fmt.Sprintf("ContainerCreate failed with name '%s'", containerName), err
 	}
 	err = cli.ContainerStart(ctx, respContainerCreater.ID, types.ContainerStartOptions{})
 	if err != nil {

--- a/api/docker.go
+++ b/api/docker.go
@@ -89,7 +89,7 @@ func startContainer(ctx context.Context, cli *client.Client, imgDocker string, p
 			Binds: []string{"/var/run/docker.sock:/var/run/docker.sock"},
 		}
 	}
-	containerName := randSeq(10)
+	containerName := randSeq(10) + "-previs"
 	respContainerCreater, err := cli.ContainerCreate(ctx, &container.Config{
 		Image: "previs",
 		Tty:   true,


### PR DESCRIPTION
Two bug fixes:
(1) Fails if container name "previs" already exists
(2) Cleanup error when images exist without any tag